### PR TITLE
Add delayed job to handle background jobs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'pg'
 gem 'puma', '~> 3.7'
 gem 'dotenv-rails'
 gem 'attr_encrypted', '~> 3.0.0'
+gem 'delayed_job_active_record'
 
 group :development, :test do
   gem 'pry-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,6 +49,11 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.4)
+    delayed_job (4.1.5)
+      activesupport (>= 3.0, < 5.3)
+    delayed_job_active_record (4.1.3)
+      activerecord (>= 3.0, < 5.3)
+      delayed_job (>= 3.0, < 5)
     diff-lcs (1.3)
     dotenv (2.4.0)
     dotenv-rails (2.4.0)
@@ -159,6 +164,7 @@ PLATFORMS
 
 DEPENDENCIES
   attr_encrypted (~> 3.0.0)
+  delayed_job_active_record
   dotenv-rails
   listen (>= 3.0.5, < 3.2)
   pg

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,3 @@
+web: bundle exec rails server -p $PORT
+worker: rake jobs:work
+release: ./bin/release_tasks

--- a/bin/delayed_job
+++ b/bin/delayed_job
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
+require 'delayed/command'
+Delayed::Command.new(ARGV).daemonize

--- a/bin/release_tasks
+++ b/bin/release_tasks
@@ -1,0 +1,1 @@
+bundle exec rake db:migrate

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,16 +18,8 @@ Bundler.require(*Rails.groups)
 
 module SudoSandwich
   class Application < Rails::Application
-    # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.1
-
-    # Settings in config/environments/* take precedence over those specified here.
-    # Application configuration should go into files in config/initializers
-    # -- all .rb files in that directory are automatically loaded.
-
-    # Only loads a smaller set of middleware suitable for API only apps.
-    # Middleware like session, flash, cookies can be added back manually.
-    # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+    config.active_job.queue_adapter = :delayed_job
   end
 end

--- a/db/migrate/20180612214514_create_delayed_jobs.rb
+++ b/db/migrate/20180612214514_create_delayed_jobs.rb
@@ -1,0 +1,22 @@
+class CreateDelayedJobs < ActiveRecord::Migration[5.1]
+  def self.up
+    create_table :delayed_jobs, force: true do |table|
+      table.integer :priority, default: 0, null: false # Allows some jobs to jump to the front of the queue
+      table.integer :attempts, default: 0, null: false # Provides for retries, but still fail eventually.
+      table.text :handler,                 null: false # YAML-encoded string of the object that will do work
+      table.text :last_error                           # reason for last failure (See Note below)
+      table.datetime :run_at                           # When to run. Could be Time.zone.now for immediately, or sometime in the future.
+      table.datetime :locked_at                        # Set when a client is working on this object
+      table.datetime :failed_at                        # Set when all retries have failed (actually, by default, the record is deleted instead)
+      table.string :locked_by                          # Who is working on this object (if locked)
+      table.string :queue                              # The name of the queue this job is in
+      table.timestamps null: true
+    end
+
+    add_index :delayed_jobs, [:priority, :run_at], name: "delayed_jobs_priority"
+  end
+
+  def self.down
+    drop_table :delayed_jobs
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,25 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180612160331) do
+ActiveRecord::Schema.define(version: 20180612214514) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "delayed_jobs", force: :cascade do |t|
+    t.integer "priority", default: 0, null: false
+    t.integer "attempts", default: 0, null: false
+    t.text "handler", null: false
+    t.text "last_error"
+    t.datetime "run_at"
+    t.datetime "locked_at"
+    t.datetime "failed_at"
+    t.string "locked_by"
+    t.string "queue"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["priority", "run_at"], name: "delayed_jobs_priority"
+  end
 
   create_table "sandwiches", force: :cascade do |t|
     t.datetime "created_at", null: false


### PR DESCRIPTION
* Reasoning: most Herokai recommend sidekiq, but requiring redis seems
like an unnecessary burden for a toy app like this.
* Second Herokai recommendation is que, which I found to have lacking
docs (did not work when following README instructions) and as far as I
can tell is less commonly used than DJ. https://github.com/chanks/que