### PR TITLE
Fix issue with Excon

### DIFF
--- a/app/services/grant_code_exchanger.rb
+++ b/app/services/grant_code_exchanger.rb
@@ -31,7 +31,7 @@ class GrantCodeExchanger
   def response
     Excon.new(BASE_URL).post(
       path: "/oauth/token",
-      params: {
+      query: {
         code: oauth_grant_code,
         grant_type: GRANT_TYPE,
         client_secret: client_secret,


### PR DESCRIPTION
* Was going to right path, but params were being passed with wrong key
* For future ref, this is the response body when the grant code is
expired:

{
    "id": "unauthorized",
    "message": "OAuth authorization invalid."
}

Response code is 401. Might want to log that in the future.