### PR TITLE
Provision non-test plans asynchronously

### DIFF
--- a/app/controllers/heroku/resources_controller.rb
+++ b/app/controllers/heroku/resources_controller.rb
@@ -5,10 +5,10 @@ module Heroku
       enqueue_token_exchange_job(sandwich)
 
       if plan == Sandwich::BASE_PLAN # synchronous provisioning
-        message = 'Thanks for using Sudo Sandwich.'
+        message = 'Thanks for using Sudo Sandwich. Your add-on is available for use immediately!'
         status = 200
       else # async provisioning
-        message = 'Your add-on is being provisioned. It will be available shortly.'
+        message = 'Sudo Sandwich is being provisioned. It will be available shortly.'
         status = 202
       end
 

--- a/app/controllers/heroku/resources_controller.rb
+++ b/app/controllers/heroku/resources_controller.rb
@@ -59,10 +59,7 @@ module Heroku
     end
 
     def enqueue_token_exchange_job(sandwich)
-      ExchangeGrantTokenJob.perform_later(
-        sandwich_id: sandwich.id,
-        sandwich_plan: sandwich.plan,
-      )
+      ExchangeGrantTokenJob.perform_later(sandwich_id: sandwich.id)
     end
 
     def heroku_uuid

--- a/app/jobs/exchange_grant_token_job.rb
+++ b/app/jobs/exchange_grant_token_job.rb
@@ -1,10 +1,13 @@
 class ExchangeGrantTokenJob < ApplicationJob
   queue_as :default
 
-  def perform(heroku_uuid:, oauth_grant_code:)
+  def perform(sandwich_id:, sandwich_plan:)
     GrantCodeExchanger.new(
-      heroku_uuid: heroku_uuid,
-      oauth_grant_code: oauth_grant_code,
+      sandwich_id: sandwich_id,
     ).run
+
+    if sandwich_plan != Sandwich::BASE_PLAN
+      ProvisionPlanJob.perform_later(sandwich_id: sandwich_id)
+    end
   end
 end

--- a/app/jobs/exchange_grant_token_job.rb
+++ b/app/jobs/exchange_grant_token_job.rb
@@ -1,13 +1,19 @@
 class ExchangeGrantTokenJob < ApplicationJob
   queue_as :default
 
-  def perform(sandwich_id:, sandwich_plan:)
+  def perform(sandwich_id:)
     GrantCodeExchanger.new(
       sandwich_id: sandwich_id,
     ).run
 
-    if sandwich_plan != Sandwich::BASE_PLAN
+    if sandwich(sandwich_id).not_provisioned?
       ProvisionPlanJob.perform_later(sandwich_id: sandwich_id)
     end
+  end
+
+  private
+
+  def sandwich(sandwich_id)
+    Sandwich.find(sandwich_id)
   end
 end

--- a/app/jobs/provision_plan_job.rb
+++ b/app/jobs/provision_plan_job.rb
@@ -1,0 +1,7 @@
+class ProvisionPlanJob < ApplicationJob
+  queue_as :default
+
+  def perform(sandwich_id:)
+    PlanProvisioner.new(sandwich_id: sandwich_id).run
+  end
+end

--- a/app/models/sandwich.rb
+++ b/app/models/sandwich.rb
@@ -1,6 +1,7 @@
 class Sandwich < ActiveRecord::Base
+  BASE_PLAN = 'test'.freeze
   PLAN_CONFIG = {
-    'test' => 'This is a test',
+    BASE_PLAN => 'This is a test',
     'pbj' => 'Make me a PB&J!',
     'blt' => 'Make me a BLT!',
   }.freeze

--- a/app/models/sandwich.rb
+++ b/app/models/sandwich.rb
@@ -15,4 +15,8 @@ class Sandwich < ActiveRecord::Base
   attr_encrypted :refresh_token, key: ENV['ENCRYPTION_KEY']
 
   validates :plan, inclusion: { in: PLAN_CONFIG.keys }
+
+  def not_provisioned?
+    state != 'provisioned'
+  end
 end

--- a/app/services/access_token_refresher.rb
+++ b/app/services/access_token_refresher.rb
@@ -1,5 +1,5 @@
-class GrantCodeExchanger
-  GRANT_TYPE = 'authorization_code'
+class AccessTokenRefresher
+  GRANT_TYPE = 'refresh_token'
   BASE_URL = 'https://id.heroku.com'
 
   def initialize(sandwich_id:, client_secret: ENV.fetch('CLIENT_SECRET'))
@@ -10,7 +10,6 @@ class GrantCodeExchanger
   def run
     sandwich.update!(
       access_token: response_body[:access_token],
-      refresh_token: response_body[:refresh_token],
       access_token_expires_at: expires_at
     )
   end
@@ -31,7 +30,7 @@ class GrantCodeExchanger
     Excon.new(BASE_URL).post(
       path: "/oauth/token",
       query: {
-        code: sandwich.oauth_grant_code,
+        refresh_token: sandwich.refresh_token,
         grant_type: GRANT_TYPE,
         client_secret: client_secret,
       }

--- a/app/services/plan_provisioner.rb
+++ b/app/services/plan_provisioner.rb
@@ -1,0 +1,43 @@
+class PlanProvisioner
+  BASE_URL = 'https://api.heroku.com'
+
+  def initialize(sandwich_id:)
+    @sandwich_id = sandwich_id
+  end
+
+  def run
+    if sandwich.access_token_expires_at < (Time.now.utc - 90)
+      AccessTokenRefresher.new(sandwich_id: sandwich_id).run
+    end
+
+    perform_request.body
+  end
+
+  private
+
+  attr_reader :sandwich_id
+
+  def perform_request
+    Excon.new(BASE_URL).post(
+      path: "/addons/#{heroku_uuid}/actions/provision",
+      headers: {
+        'Accept' => 'application/vnd.heroku+json; version=3',
+        'Authorization' => "Bearer #{access_token}",
+        'Content-Type' => 'application/json',
+      }
+    )
+  end
+
+  def heroku_uuid
+    sandwich.heroku_uuid
+  end
+
+  def access_token
+    sandwich.access_token
+  end
+
+  def sandwich
+    @_sandwich ||= Sandwich.find(sandwich_id)
+  end
+
+end

--- a/app/services/plan_provisioner.rb
+++ b/app/services/plan_provisioner.rb
@@ -10,7 +10,8 @@ class PlanProvisioner
       AccessTokenRefresher.new(sandwich_id: sandwich_id).run
     end
 
-    perform_request.body
+    perform_request
+    sandwich.update(state: 'provisioned')
   end
 
   private

--- a/db/migrate/20180620163102_add_state_to_sandwiches.rb
+++ b/db/migrate/20180620163102_add_state_to_sandwiches.rb
@@ -1,0 +1,5 @@
+class AddStateToSandwiches < ActiveRecord::Migration[5.1]
+  def change
+    add_column :sandwiches, :state, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180614161254) do
+ActiveRecord::Schema.define(version: 20180620163102) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -42,6 +42,7 @@ ActiveRecord::Schema.define(version: 20180614161254) do
     t.string "encrypted_refresh_token_iv"
     t.datetime "access_token_expires_at"
     t.string "plan"
+    t.string "state"
   end
 
 end

--- a/spec/controllers/heroku/resources_controller_spec.rb
+++ b/spec/controllers/heroku/resources_controller_spec.rb
@@ -2,43 +2,8 @@ require 'rails_helper'
 
 RSpec.describe Heroku::ResourcesController do
   describe 'POST /heroku/resources' do
-    it 'returns a 200' do
-      stub_grant_code_exchanger
-
-      post :create, params: {
-        'uuid' => '123ABC',
-        'plan' => 'test',
-        'oauth_grant': {
-          'code': 'supersecretcode'
-        }
-      }
-
-      expect(response.code).to eq('200')
-    end
-
-    it 'returns the correct json response' do
-      stub_grant_code_exchanger
-      heroku_uuid = '123-ABC-456-DEF'
-      expected_response = {
-        id: heroku_uuid,
-        config: {
-          SUDO_SANDWICH_COMMAND: 'Make me a PB&J!'
-        },
-        message: 'Thanks for using Sudo Sandwich.'
-      }
-
-      post :create, params: {
-        'uuid' => heroku_uuid,
-        'plan' => 'pbj',
-        'oauth_grant': {
-          'code': 'sekret'
-        }
-      }
-
-      expect(parsed_response_body).to eq(expected_response)
-    end
-
-    it 'saves the plan and encrypted oauth grant code' do
+    it 'enqueues the ExchangeGrantTokenJob' do
+      http_login(ENV['SLUG'], ENV['PASSWORD'])
       stub_grant_code_exchanger
       heroku_uuid = '123-ABC-456-DEF'
       code = 'supersecretcode'
@@ -50,17 +15,114 @@ RSpec.describe Heroku::ResourcesController do
           'code': code
         }
       }
-
       sandwich = Sandwich.find_by(heroku_uuid: heroku_uuid)
 
-      expect(sandwich.oauth_grant_code).to eq(code)
-      expect(sandwich.plan).to eq('pbj')
+      expect(ExchangeGrantTokenJob).to have_received(:perform_later).
+        with(sandwich_id: sandwich.id, sandwich_plan: 'pbj')
+    end
+
+    context 'test plan' do
+      context 'synchronous provisioning' do
+        it 'returns a 200' do
+          stub_grant_code_exchanger
+
+          post :create, params: {
+            'uuid' => '123ABC',
+            'plan' => 'test',
+            'oauth_grant': {
+              'code': 'supersecretcode'
+            }
+          }
+
+          expect(response.code).to eq('200')
+        end
+
+        it 'returns the correct json response' do
+          stub_grant_code_exchanger
+          heroku_uuid = '123-ABC-456-DEF'
+          expected_response = {
+            id: heroku_uuid,
+            config: {
+              SUDO_SANDWICH_COMMAND: 'This is a test'
+            },
+            message: 'Thanks for using Sudo Sandwich.'
+          }
+
+          post :create, params: {
+            'uuid' => heroku_uuid,
+            'plan' => 'test',
+            'oauth_grant': {
+              'code': 'sekret'
+            }
+          }
+
+          expect(parsed_response_body).to eq(expected_response)
+        end
+
+        it 'saves the plan and encrypted oauth grant code' do
+          stub_grant_code_exchanger
+          heroku_uuid = '123-ABC-456-DEF'
+          code = 'supersecretcode'
+
+          post :create, params: {
+            'uuid' => heroku_uuid,
+            'plan' => 'test',
+            'oauth_grant': {
+              'code': code
+            }
+          }
+
+          sandwich = Sandwich.find_by(heroku_uuid: heroku_uuid)
+
+          expect(sandwich.oauth_grant_code).to eq(code)
+          expect(sandwich.plan).to eq('test')
+        end
+      end
+    end
+  end
+
+  context 'not a test plan' do
+    context 'asynchronous provisioning' do
+      it 'returns a 202' do
+        stub_grant_code_exchanger
+
+        post :create, params: {
+          'uuid' => '123ABC',
+          'plan' => 'pbj',
+          'oauth_grant': {
+            'code': 'supersecretcode'
+          }
+        }
+
+        expect(response.code).to eq('202')
+      end
+
+      it 'returns the correct json response' do
+        stub_grant_code_exchanger
+        heroku_uuid = '123-ABC-456-DEF'
+        expected_response = {
+          id: heroku_uuid,
+          config: {
+            SUDO_SANDWICH_COMMAND: 'Make me a PB&J!'
+          },
+          message: 'Your add-on is being provisioned. It will be available shortly.'
+        }
+
+        post :create, params: {
+          'uuid' => heroku_uuid,
+          'plan' => 'pbj',
+          'oauth_grant': {
+            'code': 'sekret'
+          }
+        }
+
+        expect(parsed_response_body).to eq(expected_response)
+      end
     end
   end
 
   describe 'PUT /heroku/resources' do
     it 'changes the plan for the heroku_uuid passed in' do
-      http_login(ENV['SLUG'], ENV['PASSWORD'])
       heroku_uuid = '123-ABC-456-DEF'
       old_plan = "pbj"
       new_plan = "blt"
@@ -72,7 +134,6 @@ RSpec.describe Heroku::ResourcesController do
     end
 
     it 'returns the expected response' do
-      http_login(ENV['SLUG'], ENV['PASSWORD'])
       heroku_uuid = '123-ABC-456-DEF'
       old_plan = 'pbj'
       new_plan = 'blt'
@@ -88,29 +149,10 @@ RSpec.describe Heroku::ResourcesController do
 
       expect(parsed_response_body).to eq(expected_response)
     end
-
-    it 'enqueues the ExchangeGrantTokenJob' do
-      http_login(ENV['SLUG'], ENV['PASSWORD'])
-      stub_grant_code_exchanger
-      heroku_uuid = '123-ABC-456-DEF'
-      code = 'supersecretcode'
-
-      post :create, params: {
-        'uuid' => heroku_uuid,
-        'plan' => 'pbj',
-        'oauth_grant': {
-          'code': code
-        }
-      }
-
-      expect(ExchangeGrantTokenJob).to have_received(:perform_later).
-        with(heroku_uuid: heroku_uuid, oauth_grant_code: code)
-    end
   end
 
   describe 'POST /heroku/resources' do
     it 'returns a 204' do
-      http_login(ENV['SLUG'], ENV['PASSWORD'])
       stub_grant_code_exchanger
       heroku_uuid = '123-ABC'
       sandwich = double(destroy!: true)
@@ -122,7 +164,6 @@ RSpec.describe Heroku::ResourcesController do
     end
 
     it 'deletes the associated sandwich record' do
-      http_login(ENV['SLUG'], ENV['PASSWORD'])
       stub_grant_code_exchanger
       heroku_uuid = '123-ABC'
       Sandwich.create!(heroku_uuid: heroku_uuid, plan: 'test')

--- a/spec/controllers/heroku/resources_controller_spec.rb
+++ b/spec/controllers/heroku/resources_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Heroku::ResourcesController do
       sandwich = Sandwich.find_by(heroku_uuid: heroku_uuid)
 
       expect(ExchangeGrantTokenJob).to have_received(:perform_later).
-        with(sandwich_id: sandwich.id, sandwich_plan: 'pbj')
+        with(sandwich_id: sandwich.id)
     end
 
     context 'test plan' do

--- a/spec/controllers/heroku/resources_controller_spec.rb
+++ b/spec/controllers/heroku/resources_controller_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Heroku::ResourcesController do
             config: {
               SUDO_SANDWICH_COMMAND: 'This is a test'
             },
-            message: 'Thanks for using Sudo Sandwich.'
+            message: 'Thanks for using Sudo Sandwich. Your add-on is available for use immediately!'
           }
 
           post :create, params: {
@@ -105,7 +105,7 @@ RSpec.describe Heroku::ResourcesController do
           config: {
             SUDO_SANDWICH_COMMAND: 'Make me a PB&J!'
           },
-          message: 'Your add-on is being provisioned. It will be available shortly.'
+          message: 'Sudo Sandwich is being provisioned. It will be available shortly.'
         }
 
         post :create, params: {

--- a/spec/controllers/heroku/resources_controller_spec.rb
+++ b/spec/controllers/heroku/resources_controller_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Heroku::ResourcesController do
 
     context 'test plan' do
       context 'synchronous provisioning' do
-        it 'returns a 200' do
+        it 'returns a 200, state of provisioned' do
           stub_grant_code_exchanger
 
           post :create, params: {
@@ -33,8 +33,10 @@ RSpec.describe Heroku::ResourcesController do
               'code': 'supersecretcode'
             }
           }
+          sandwich = Sandwich.find_by(heroku_uuid: '123ABC')
 
           expect(response.code).to eq('200')
+          expect(sandwich.state).to eq('provisioned')
         end
 
         it 'returns the correct json response' do
@@ -55,8 +57,10 @@ RSpec.describe Heroku::ResourcesController do
               'code': 'sekret'
             }
           }
+          sandwich = Sandwich.find_by(heroku_uuid: heroku_uuid)
 
           expect(parsed_response_body).to eq(expected_response)
+          expect(sandwich.state).to eq('provisioned')
         end
 
         it 'saves the plan and encrypted oauth grant code' do

--- a/spec/jobs/exchange_grant_token_job_spec.rb
+++ b/spec/jobs/exchange_grant_token_job_spec.rb
@@ -3,14 +3,11 @@ require 'rails_helper'
 RSpec.describe ExchangeGrantTokenJob do
   describe '#perform' do
     it 'calls the grant code exchanger class' do
-      sandwich = double(id: 123, plan: 'test')
+      sandwich = Sandwich.create!(heroku_uuid: 123, plan: 'test', state: 'provisioned')
       exchanger_double = double(run: true)
       allow(GrantCodeExchanger).to receive(:new).and_return(exchanger_double)
 
-      ExchangeGrantTokenJob.perform_now(
-        sandwich_id: sandwich.id,
-        sandwich_plan:  sandwich.plan
-      )
+      ExchangeGrantTokenJob.perform_now(sandwich_id: sandwich.id)
 
       expect(GrantCodeExchanger).to have_received(:new).with(
         sandwich_id: sandwich.id,
@@ -18,34 +15,28 @@ RSpec.describe ExchangeGrantTokenJob do
       expect(exchanger_double).to have_received(:run)
     end
 
-    context 'plan that requires async provisioning' do
-      it 'enqueues the provisioning job' do
-        sandwich = double(id: '123', plan: 'pbj')
+    context 'is provisioning' do
+      it 'enqueues the provision plan job' do
+        sandwich = Sandwich.create!(heroku_uuid: '123', plan: 'pbj', state: 'provisioning')
         exchanger_double = double(run: true)
         allow(GrantCodeExchanger).to receive(:new).and_return(exchanger_double)
         allow(ProvisionPlanJob).to receive(:perform_later)
 
-        ExchangeGrantTokenJob.perform_now(
-          sandwich_id: sandwich.id,
-          sandwich_plan:  sandwich.plan
-        )
+        ExchangeGrantTokenJob.perform_now(sandwich_id: sandwich.id)
 
         expect(ProvisionPlanJob).to have_received(:perform_later).
           with(sandwich_id: sandwich.id)
       end
     end
 
-    context 'plan that does not require async provisioning' do
+    context 'is provisioned' do
       it 'does not enqueue the provisioning job' do
-        sandwich = double(id: '123', plan: Sandwich::BASE_PLAN)
+        sandwich = Sandwich.create!(heroku_uuid: '123', plan: 'test', state: 'provisioned')
         exchanger_double = double(run: true)
         allow(GrantCodeExchanger).to receive(:new).and_return(exchanger_double)
         allow(ProvisionPlanJob).to receive(:perform_later)
 
-        ExchangeGrantTokenJob.perform_now(
-          sandwich_id: sandwich.id,
-          sandwich_plan:  sandwich.plan
-        )
+        ExchangeGrantTokenJob.perform_now(sandwich_id: sandwich.id)
 
         expect(ProvisionPlanJob).not_to have_received(:perform_later)
       end

--- a/spec/jobs/exchange_grant_token_job_spec.rb
+++ b/spec/jobs/exchange_grant_token_job_spec.rb
@@ -3,20 +3,52 @@ require 'rails_helper'
 RSpec.describe ExchangeGrantTokenJob do
   describe '#perform' do
     it 'calls the grant code exchanger class' do
+      sandwich = double(id: 123, plan: 'test')
       exchanger_double = double(run: true)
       allow(GrantCodeExchanger).to receive(:new).and_return(exchanger_double)
-      heroku_uuid = 'uuid'
-      oauth_grant_code = 'code'
 
       ExchangeGrantTokenJob.perform_now(
-        heroku_uuid: heroku_uuid,
-        oauth_grant_code: oauth_grant_code,
+        sandwich_id: sandwich.id,
+        sandwich_plan:  sandwich.plan
       )
 
       expect(GrantCodeExchanger).to have_received(:new).with(
-        heroku_uuid: heroku_uuid,
-        oauth_grant_code: oauth_grant_code,
+        sandwich_id: sandwich.id,
       )
+      expect(exchanger_double).to have_received(:run)
+    end
+
+    context 'plan that requires async provisioning' do
+      it 'enqueues the provisioning job' do
+        sandwich = double(id: '123', plan: 'pbj')
+        exchanger_double = double(run: true)
+        allow(GrantCodeExchanger).to receive(:new).and_return(exchanger_double)
+        allow(ProvisionPlanJob).to receive(:perform_later)
+
+        ExchangeGrantTokenJob.perform_now(
+          sandwich_id: sandwich.id,
+          sandwich_plan:  sandwich.plan
+        )
+
+        expect(ProvisionPlanJob).to have_received(:perform_later).
+          with(sandwich_id: sandwich.id)
+      end
+    end
+
+    context 'plan that does not require async provisioning' do
+      it 'does not enqueue the provisioning job' do
+        sandwich = double(id: '123', plan: Sandwich::BASE_PLAN)
+        exchanger_double = double(run: true)
+        allow(GrantCodeExchanger).to receive(:new).and_return(exchanger_double)
+        allow(ProvisionPlanJob).to receive(:perform_later)
+
+        ExchangeGrantTokenJob.perform_now(
+          sandwich_id: sandwich.id,
+          sandwich_plan:  sandwich.plan
+        )
+
+        expect(ProvisionPlanJob).not_to have_received(:perform_later)
+      end
     end
   end
 end

--- a/spec/jobs/provision_plan_job_spec.rb
+++ b/spec/jobs/provision_plan_job_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe ProvisionPlanJob do
+  describe '#perform' do
+    it 'calls the provision plan class' do
+      sandwich = double(id: 123)
+      provisioner_double = double(run: true)
+      allow(PlanProvisioner).to receive(:new).and_return(provisioner_double)
+
+      ProvisionPlanJob.perform_now(sandwich_id: sandwich.id)
+
+      expect(PlanProvisioner).to have_received(:new).with(
+        sandwich_id: sandwich.id,
+      )
+      expect(provisioner_double).to have_received(:run)
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -13,6 +13,7 @@ Dir[Rails.root.join("spec/support/*.rb")].sort.each { |file| require file }
 RSpec.configure do |config|
   config.before(:each) do
     WebMock.stub_request(:any, /id.heroku.com/).to_rack(FakeCoreIdentityApi)
+    WebMock.stub_request(:any, /api.heroku.com/).to_rack(FakePlatformApi)
   end
 
   config.infer_base_class_for_anonymous_controllers = false

--- a/spec/services/access_token_refresher_spec.rb
+++ b/spec/services/access_token_refresher_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe AccessTokenRefresher do
+  describe '#run' do
+    it 'saves the new access_token for the sandwich' do
+      access_token_from_fixture = 'fake-access-token'
+      heroku_uuid = 'some-uuid'
+      sandwich = Sandwich.create!(
+        heroku_uuid: heroku_uuid,
+        plan: 'test',
+        access_token: 'old-access-token',
+      )
+
+      AccessTokenRefresher.new(sandwich_id: sandwich.id).run
+      sandwich.reload
+
+      expect(sandwich.access_token).to eq access_token_from_fixture
+    end
+
+    it 'saves the datetime when the new access token expires' do
+      Timecop.freeze do
+        current_time = Time.now.utc
+        expiration_time = current_time - 10.minutes
+        time = Time.now.utc
+        expires_in_seconds_from_fixture = 28799
+        expires_time = time + expires_in_seconds_from_fixture
+        heroku_uuid = 'some-uuid'
+        sandwich = Sandwich.create!(
+          heroku_uuid: heroku_uuid,
+          plan: 'test',
+          access_token_expires_at: expiration_time,
+        )
+
+        AccessTokenRefresher.new(sandwich_id: sandwich.id).run
+
+        expect(sandwich.reload.access_token_expires_at).to eq expires_time
+      end
+    end
+  end
+end

--- a/spec/services/grant_code_exchanger_spec.rb
+++ b/spec/services/grant_code_exchanger_spec.rb
@@ -6,10 +6,10 @@ RSpec.describe GrantCodeExchanger do
       refresh_token_from_fixture = 'fake-refresh-token'
       access_token_from_fixture = 'fake-access-token'
       heroku_uuid = 'some-uuid'
-      Sandwich.create!(heroku_uuid: heroku_uuid, plan: 'test')
+      sandwich = Sandwich.create!(heroku_uuid: heroku_uuid, plan: 'test')
 
-      GrantCodeExchanger.new(heroku_uuid: heroku_uuid, oauth_grant_code: 'some-code').run
-      sandwich = Sandwich.find_by(heroku_uuid: heroku_uuid)
+      GrantCodeExchanger.new(sandwich_id: sandwich.id).run
+      sandwich.reload
 
       expect(sandwich.access_token).to eq access_token_from_fixture
       expect(sandwich.refresh_token).to eq refresh_token_from_fixture
@@ -21,12 +21,11 @@ RSpec.describe GrantCodeExchanger do
         expires_in_seconds_from_fixture = 28799
         expires_time = time + expires_in_seconds_from_fixture
         heroku_uuid = 'some-uuid'
-        Sandwich.create!(heroku_uuid: heroku_uuid, plan: 'test')
+        sandwich = Sandwich.create!(heroku_uuid: heroku_uuid, plan: 'test')
 
-        GrantCodeExchanger.new(heroku_uuid: heroku_uuid, oauth_grant_code: 'some-code').run
-        sandwich = Sandwich.find_by(heroku_uuid: heroku_uuid)
+        GrantCodeExchanger.new(sandwich_id: sandwich.id).run
 
-        expect(sandwich.access_token_expires_at).to eq expires_time
+        expect(sandwich.reload.access_token_expires_at).to eq expires_time
       end
     end
   end

--- a/spec/services/plan_provisioner_spec.rb
+++ b/spec/services/plan_provisioner_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe PlanProvisioner do
+  describe '#run' do
+    it 'returns the expected response from api.heroku.com' do
+      heroku_uuid = 'some-uuid'
+      sandwich = Sandwich.create!(
+        heroku_uuid: heroku_uuid,
+        plan: 'test',
+        access_token_expires_at: Time.now.utc + 1.day,
+      )
+
+      response = PlanProvisioner.new(sandwich_id: sandwich.id).run
+
+      expect(JSON.parse(response)['state']).to eq 'provisioned'
+    end
+
+    context 'access token is expired' do
+      it 'refreshes the access_token' do
+        Timecop.freeze do
+          current_time = Time.now.utc
+          expiration_time = current_time - 10.minutes
+          heroku_uuid = 'some-uuid'
+          sandwich = Sandwich.create!(
+            heroku_uuid: heroku_uuid,
+            plan: 'pbj',
+            access_token_expires_at: expiration_time,
+          )
+          refresher_double = double(run: true)
+          allow(AccessTokenRefresher).to receive(:new).and_return(refresher_double)
+
+          PlanProvisioner.new(sandwich_id: sandwich.id).run
+
+          expect(AccessTokenRefresher).to have_received(:new).with(
+            sandwich_id: sandwich.id,
+          )
+        end
+      end
+    end
+
+    context 'access token is not expired' do
+      it 'does not refresh the access token' do
+        Timecop.freeze do
+          current_time = Time.now.utc
+          expiration_time = current_time + 10.minutes
+          heroku_uuid = 'some-uuid'
+          sandwich = Sandwich.create!(
+            heroku_uuid: heroku_uuid,
+            plan: 'pbj',
+            access_token_expires_at: expiration_time,
+          )
+          allow(AccessTokenRefresher).to receive(:new)
+
+          PlanProvisioner.new(sandwich_id: sandwich.id).run
+
+          expect(AccessTokenRefresher).not_to have_received(:new)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/plan_provisioner_spec.rb
+++ b/spec/services/plan_provisioner_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe PlanProvisioner do
   describe '#run' do
-    it 'returns the expected response from api.heroku.com' do
+    it 'updates the state to provisioned' do
       heroku_uuid = 'some-uuid'
       sandwich = Sandwich.create!(
         heroku_uuid: heroku_uuid,
@@ -10,9 +10,9 @@ RSpec.describe PlanProvisioner do
         access_token_expires_at: Time.now.utc + 1.day,
       )
 
-      response = PlanProvisioner.new(sandwich_id: sandwich.id).run
+      PlanProvisioner.new(sandwich_id: sandwich.id).run
 
-      expect(JSON.parse(response)['state']).to eq 'provisioned'
+      expect(sandwich.reload.state).to eq 'provisioned'
     end
 
     context 'access token is expired' do

--- a/spec/support/fake_platform_api.rb
+++ b/spec/support/fake_platform_api.rb
@@ -1,0 +1,15 @@
+require 'sinatra/base'
+
+class FakePlatformApi < Sinatra::Base
+  post '/addons/:heroku_uuid/actions/provision' do
+    json_response 200, 'provision_plan_response.json'
+  end
+
+  private
+
+  def json_response(response_code, file_name)
+    content_type :json
+    status response_code
+    File.open(File.dirname(__FILE__) + '/fixtures/' + file_name, 'rb').read
+  end
+end

--- a/spec/support/fixtures/provision_plan_response.json
+++ b/spec/support/fixtures/provision_plan_response.json
@@ -1,0 +1,30 @@
+{
+    "actions": [],
+    "config_vars": [
+        "SUDO_SANDWICH_COMMAND"
+    ],
+    "created_at": "2018-06-19T22:59:56Z",
+    "id": "11acb356-a59d-4fd1-a36c-fc535e8604f3",
+    "name": "sudo-sandwich-vertical-92072",
+    "addon_service": {
+        "id": "d7f4826f-a81f-4b3a-bdbc-8e5c9271ae7d",
+        "name": "sudo-sandwich"
+    },
+    "plan": {
+        "id": "dc8f0102-0ff3-465d-b231-8c33835d1d36",
+        "name": "sudo-sandwich:pbj"
+    },
+    "app": {
+        "id": "439b0b54-be57-4c22-8cf6-927bad06bda4",
+        "name": "app-for-testing-add-ons"
+    },
+    "provider_id": "11acb356-a59d-4fd1-a36c-fc535e8604f3",
+    "state": "provisioned",
+    "updated_at": "2018-06-19T23:02:02Z",
+    "web_url": "https://addons-sso.heroku.com/apps/439b0b54-be57-4c22-8cf6-927bad06bda4/addons/11acb356-a59d-4fd1-a36c-fc535e8604f3",
+    "billed_price": {
+        "cents": 0,
+        "contract": false,
+        "unit": "month"
+    }
+}


### PR DESCRIPTION
* Returns a 202 for async provisioning and enqueues a job to mark the add-on as provisioned
* If the access_token is within 90 seconds of expiration, also refreshes the access token
* Following along with https://devcenter.heroku.com/articles/building-an-add-on#the-provisioning-request